### PR TITLE
  feature :  option on right click

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1,0 +1,22 @@
+const getCurrentTab = async () => {
+    if (chrome) {
+      chrome.tabs.query(
+        { active: true, lastFocusedWindow: true },
+        (arrayOfTabs) => {
+          console.log(arrayOfTabs);
+        }
+      );
+    } else {
+      browser.tabs
+        .query({ active: true, currentWindow: true })
+        .then(logCurrentTabData);
+    }
+  };
+  
+chrome.contextMenus.create({
+    title: "Shorten Url",
+    contexts: ["all"],
+    onclick: function (info, tab) {
+        getCurrentTab()
+    }
+  });


### PR DESCRIPTION
### Context menu option 

## Description
  use can now shorten current tab URL by right click on the page


## Proposed Changes:
   1.  Change 1
   1.  Change 2
   
# Checklist
- [x] Test
- [ ] Translations
- [ ] Documentations

## How Has This Been Tested?
I had tested with chrome and it's working fine with Google Chrome.

## Motivation and Context
 it solves the problem of going each time to the extension and shortening the url also it makes the whole process more easy

# Screenshots

user will have option to shorten the url once hi right clicked on the page
![Screenshot from 2020-12-19 02-22-48](https://user-images.githubusercontent.com/16479428/102660545-32a2c400-41a1-11eb-8891-688ce9830f38.png)
